### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 <img height="85px" src="https://user-images.githubusercontent.com/399657/68221862-17ceb980-ffb8-11e9-87d4-7b30b6488f16.png"/>
 
 
-`it-compromise` è un porto di [compromise](https://github.com/nlp-compromise/compromise) in italiano.
+`it-compromise` è un port di [compromise](https://github.com/nlp-compromise/compromise) in italiano.
 
 L'obiettivo di questo progetto è fornire un tagger POS piccolo, di base e basato su regole. 
 
@@ -46,7 +46,7 @@ L'obiettivo di questo progetto è fornire un tagger POS piccolo, di base e basat
 <img height="15px" src="https://user-images.githubusercontent.com/399657/68221862-17ceb980-ffb8-11e9-87d4-7b30b6488f16.png"/>
 
 ```js
-import pln from 'it-compromise'
+import nlp from 'it-compromise'
 
 let doc = nlp(`con l'autoradio sempre nella mano destra`)
 doc.match('#Noun').json()


### PR DESCRIPTION
Very small fixes:

"pnl" -> "nlp"
"porto" -> "port" (In italian, it remains port if it's related to a software porting. It is not translated to porto - that means dock)